### PR TITLE
fix(HLS): Ensure textSequenceModeOffset is updated on each offset calculation

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -140,8 +140,8 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.attemptTimestampOffsetCalculation_ = false;
 
-    /** @private {number} */
-    this.textSequenceModeOffset_ = 0;
+    /** @private {!shaka.util.PublicPromise.<number>} */
+    this.textSequenceModeOffset_ = new shaka.util.PublicPromise();
 
     /** @private {boolean} */
     this.needSplitMuxedContent_ = false;
@@ -837,7 +837,12 @@ shaka.media.MediaSourceEngine = class {
     if (contentType == ContentType.TEXT) {
       if (this.sequenceMode_) {
         // This won't be known until the first video segment is appended.
-        this.textEngine_.setTimestampOffset(this.textSequenceModeOffset_);
+        const offset = await this.textSequenceModeOffset_;
+        this.textEngine_.setTimestampOffset(offset);
+
+        // Reset the promise in case the timestamp offset changed during
+        // a period/discontinuity transition.
+        this.textSequenceModeOffset_ = new shaka.util.PublicPromise();
       }
       await this.textEngine_.appendBuffer(
           data,
@@ -895,7 +900,7 @@ shaka.media.MediaSourceEngine = class {
             contentType == ContentType.VIDEO ||
             !(ContentType.VIDEO in this.sourceBuffers_);
         if (this.sequenceMode_ && isBestSourceBufferForTimestamps) {
-          this.textSequenceModeOffset_ = timestampOffset;
+          this.textSequenceModeOffset_.resolve(timestampOffset);
         }
       }
     }

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -132,7 +132,7 @@ shaka.media.MediaSourceEngine = class {
     this.sequenceMode_ = false;
 
     /** @private {number} */
-    this.newTextTimestampOffset_ = 0;
+    this.textTimestampOffset_ = 0;
 
     /** @private {string} */
     this.manifestType_ = shaka.media.ManifestParser.UNKNOWN;
@@ -841,19 +841,13 @@ shaka.media.MediaSourceEngine = class {
       const timestamp = this.getTimestampAndDispatchMetadata_(
           contentType, data, reference, stream.mimeType, reference.startTime);
       if (timestamp != null) {
-        this.newTextTimestampOffset_ = reference.startTime - timestamp;
+        this.textTimestampOffset_ = reference.startTime - timestamp;
       }
     }
     if (contentType == ContentType.TEXT) {
       if (this.sequenceMode_) {
         // This won't be known until the first video segment is appended.
-        const offset = await this.textSequenceModeOffset_;
-        // Set new text offset after each discontinuity
-        if (reference.discontinuitySequence === 0) {
-          this.textEngine_.setTimestampOffset(offset);
-        } else {
-          this.textEngine_.setTimestampOffset(this.newTextTimestampOffset_);
-        }
+        this.textEngine_.setTimestampOffset(this.textTimestampOffset_);
       }
       await this.textEngine_.appendBuffer(
           data,

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -131,6 +131,9 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.sequenceMode_ = false;
 
+    /** @private {number} */
+    this.newTextTimestampOffset_ = 0;
+
     /** @private {string} */
     this.manifestType_ = shaka.media.ManifestParser.UNKNOWN;
 
@@ -834,11 +837,23 @@ shaka.media.MediaSourceEngine = class {
       adaptation = false, isChunkedData = false, fromSplit = false) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
 
+    if (contentType == ContentType.VIDEO) {
+      const timestamp = this.getTimestampAndDispatchMetadata_(
+          contentType, data, reference, stream.mimeType, reference.startTime);
+      if (timestamp != null) {
+        this.newTextTimestampOffset_ = reference.startTime - timestamp;
+      }
+    }
     if (contentType == ContentType.TEXT) {
       if (this.sequenceMode_) {
         // This won't be known until the first video segment is appended.
         const offset = await this.textSequenceModeOffset_;
-        this.textEngine_.setTimestampOffset(offset);
+        // Set new text offset after each discontinuity
+        if (reference.discontinuitySequence === 0) {
+          this.textEngine_.setTimestampOffset(offset);
+        } else {
+          this.textEngine_.setTimestampOffset(this.newTextTimestampOffset_);
+        }
       }
       await this.textEngine_.appendBuffer(
           data,

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -131,9 +131,6 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.sequenceMode_ = false;
 
-    /** @private {number} */
-    this.textTimestampOffset_ = 0;
-
     /** @private {string} */
     this.manifestType_ = shaka.media.ManifestParser.UNKNOWN;
 
@@ -143,8 +140,8 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.attemptTimestampOffsetCalculation_ = false;
 
-    /** @private {!shaka.util.PublicPromise.<number>} */
-    this.textSequenceModeOffset_ = new shaka.util.PublicPromise();
+    /** @private {number} */
+    this.textSequenceModeOffset_ = 0;
 
     /** @private {boolean} */
     this.needSplitMuxedContent_ = false;
@@ -837,17 +834,10 @@ shaka.media.MediaSourceEngine = class {
       adaptation = false, isChunkedData = false, fromSplit = false) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
 
-    if (contentType == ContentType.VIDEO) {
-      const timestamp = this.getTimestampAndDispatchMetadata_(
-          contentType, data, reference, stream.mimeType, reference.startTime);
-      if (timestamp != null) {
-        this.textTimestampOffset_ = reference.startTime - timestamp;
-      }
-    }
     if (contentType == ContentType.TEXT) {
       if (this.sequenceMode_) {
         // This won't be known until the first video segment is appended.
-        this.textEngine_.setTimestampOffset(this.textTimestampOffset_);
+        this.textEngine_.setTimestampOffset(this.textSequenceModeOffset_);
       }
       await this.textEngine_.appendBuffer(
           data,
@@ -905,7 +895,7 @@ shaka.media.MediaSourceEngine = class {
             contentType == ContentType.VIDEO ||
             !(ContentType.VIDEO in this.sourceBuffers_);
         if (this.sequenceMode_ && isBestSourceBufferForTimestamps) {
-          this.textSequenceModeOffset_.resolve(timestampOffset);
+          this.textSequenceModeOffset_ = timestampOffset;
         }
       }
     }


### PR DESCRIPTION
**DO NOT MERGE!**
PR just to review diff of changes. 

This resolves [AVIAJS-10](https://paramount.atlassian.net/browse/AVIAJS-10), captions sync issue with Pluto HLS streams.

- Previously the base offset, used for `time.periodStart` in [vtt_text_parser](https://github.com/shaka-project/shaka-player/blob/03bb463a724483c88df818b11c807a0fdc11cccb/lib/text/vtt_text_parser.js#L174), was calculated and set at stream start and never updated.
- The correct offset is actually being calculated on every call to appendBuffer, but when it is applied to the text engine (`textEngine_.setTimestampOffset`) in order to update `time.periodStart`,  it only ever uses the initial calculated offset. 
- That is because `this.textSequenceModeOffset_` is typed and initiated as a Promise. The value is updated by calling `this.textSequenceModeOffset_.resolve(value)`. However, once a promise is resolved, calling resolve on it again has no effect. So the first value passed is locked in and used in all subsequent calculations.
- This PR changes `this.textSequenceModeOffset_` type from a Promise to a number and directly updates it's value on each `appendBuffer` of type video.

[AVIAJS-10]: https://paramount.atlassian.net/browse/AVIAJS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ