### PR TITLE
fix: ensure variants are created for each video representation

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -736,7 +736,7 @@ shaka.util.PeriodCombiner = class {
         }
       }
       // In cases where we have the same video codec but different
-      // codec tags in matched representations across periods
+      // codec bases in matched representations across periods
       // (e.g. HEVC as hev and hvc), we don't want to delete the matched stream
       // from unusedStreamsPerPeriod until an outputStream for each
       // video representation has been created.

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -708,6 +708,7 @@ shaka.util.PeriodCombiner = class {
       periodsMissing) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
     const LanguageUtils = shaka.util.LanguageUtils;
+    const MimeUtils = shaka.util.MimeUtils;
     const matches = outputStream.matchedStreams;
 
     // Assure the compiler that matches didn't become null during the async
@@ -722,15 +723,33 @@ shaka.util.PeriodCombiner = class {
       const match = matches[i];
       concat(outputStream, match);
 
+      let used = true;
       // We only consider an audio stream "used" if its language is related to
       // the output language.  There are scenarios where we want to generate
       // separate tracks for each language, even when we are forced to connect
       // unrelated languages across periods.
-      let used = true;
       if (outputStream.type == ContentType.AUDIO) {
         const relatedness = LanguageUtils.relatedness(
             outputStream.language, match.language);
         if (relatedness == 0) {
+          used = false;
+        }
+      }
+      // In cases where we have the same video codec but different
+      // codec tags in matched representations across periods
+      // (e.g. HEVC as hev and hvc), we don't want to delete the matched stream
+      // from unusedStreamsPerPeriod until an outputStream for each
+      // video representation has been created.
+      if (outputStream.type == ContentType.VIDEO) {
+        const outputStreamNormalizedCodec =
+            MimeUtils.getNormalizedCodec(outputStream.codecs);
+        const matchNormalizedCodec = MimeUtils.getNormalizedCodec(match.codecs);
+        const outputStreamCodecBase =
+            MimeUtils.getCodecBase(outputStream.codecs);
+        const matchCodecBase = MimeUtils.getCodecBase(match.codecs);
+
+        if (outputStreamNormalizedCodec == matchNormalizedCodec &&
+              outputStreamCodecBase != matchCodecBase) {
           used = false;
         }
       }

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -723,11 +723,11 @@ shaka.util.PeriodCombiner = class {
       const match = matches[i];
       concat(outputStream, match);
 
-      let used = true;
       // We only consider an audio stream "used" if its language is related to
       // the output language.  There are scenarios where we want to generate
       // separate tracks for each language, even when we are forced to connect
       // unrelated languages across periods.
+      let used = true;
       if (outputStream.type == ContentType.AUDIO) {
         const relatedness = LanguageUtils.relatedness(
             outputStream.language, match.language);

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -1124,7 +1124,8 @@ describe('PeriodCombiner', () => {
     expect(audio2.originalId).toBe('2,4');
   });
 
-  it('Matches streams with related codecs', async () => {
+  it('Creates a video stream for each unique codec base ' +
+  'and matches streams with related codecs', async () => {
     const stream1 = makeVideoStream(1080);
     stream1.originalId = '1';
     stream1.bandwidth = 120000;
@@ -1189,19 +1190,35 @@ describe('PeriodCombiner', () => {
 
     await combiner.combinePeriods(periods, /* isDynamic= */ true);
     const variants = combiner.getVariants();
-    expect(variants.length).toBe(4);
+    expect(variants.length).toBe(7);
     // We can use the originalId field to see what each track is composed of.
     const video1 = variants[0].video;
     expect(video1.originalId).toBe('1,2');
+    expect(video1.codecs).toBe(stream1.codecs);
 
     const video2 = variants[1].video;
     expect(video2.originalId).toBe('3,4');
+    expect(video2.codecs).toBe(stream3.codecs);
 
     const video3 = variants[2].video;
     expect(video3.originalId).toBe('5,6');
+    expect(video3.codecs).toBe(stream5.codecs);
 
     const video4 = variants[3].video;
     expect(video4.originalId).toBe('7,8');
+    expect(video4.codecs).toBe(stream7.codecs);
+
+    const video5 = variants[4].video;
+    expect(video5.originalId).toBe('1,2');
+    expect(video5.codecs).toBe(stream2.codecs);
+
+    const video6 = variants[5].video;
+    expect(video6.originalId).toBe('3,4');
+    expect(video6.codecs).toBe(stream4.codecs);
+
+    const video7 = variants[6].video;
+    expect(video7.originalId).toBe('5,6');
+    expect(video7.codecs).toBe(stream6.codecs);
   });
 
   it('Matches streams with most roles in common', async () => {


### PR DESCRIPTION
**_Draft PR to review before submitting to Shaka. DO NOT MERGE._** 

Resolves https://github.com/shaka-project/shaka-player/issues/6820.

For DAI DASH VOD manifests with mixed codecs, variants are not created for all `hvc` representations when setting `preferredVideoCodecs = ['hvc']`. 
This PR ensures variants are created for each representation before variant filtering happens. 
